### PR TITLE
Add API orchestration tab

### DIFF
--- a/web/app/(commonLayout)/api-orchestration/page.tsx
+++ b/web/app/(commonLayout)/api-orchestration/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+import type { FC } from 'react'
+import { useRouter } from 'next/navigation'
+import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAppContext } from '@/context/app-context'
+import useDocumentTitle from '@/hooks/use-document-title'
+
+const ApiOrchestrationPage: FC = () => {
+  const router = useRouter()
+  const { isCurrentWorkspaceDatasetOperator } = useAppContext()
+  const { t } = useTranslation()
+  useDocumentTitle(t('common.menus.apiOrchestration'))
+
+  useEffect(() => {
+    if (isCurrentWorkspaceDatasetOperator)
+      return router.replace('/datasets')
+  }, [isCurrentWorkspaceDatasetOperator, router])
+
+  return (
+    <div className='p-4 text-gray-500'>
+      API Orchestration Page
+    </div>
+  )
+}
+
+export default React.memo(ApiOrchestrationPage)

--- a/web/app/components/header/api-orchestration-nav/index.tsx
+++ b/web/app/components/header/api-orchestration-nav/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useTranslation } from 'react-i18next'
+import Link from 'next/link'
+import { useSelectedLayoutSegment } from 'next/navigation'
+import {
+  Webhooks,
+} from '@/app/components/base/icons/src/vender/line/development'
+import classNames from '@/utils/classnames'
+type ApiOrchestrationNavProps = {
+  className?: string
+}
+
+const ApiOrchestrationNav = ({
+  className,
+}: ApiOrchestrationNavProps) => {
+  const { t } = useTranslation()
+  const selectedSegment = useSelectedLayoutSegment()
+  const activated = selectedSegment === 'api-orchestration'
+
+  return (
+    <Link href="/api-orchestration" className={classNames(
+      'group text-sm font-medium',
+      activated && 'font-semibold bg-components-main-nav-nav-button-bg-active hover:bg-components-main-nav-nav-button-bg-active-hover shadow-md',
+      activated ? 'text-components-main-nav-nav-button-text-active' : 'text-components-main-nav-nav-button-text hover:bg-components-main-nav-nav-button-bg-hover',
+      className,
+    )}>
+      {
+        <Webhooks className='mr-2 h-4 w-4' />
+      }
+      {t('common.menus.apiOrchestration')}
+    </Link>
+  )
+}
+
+export default ApiOrchestrationNav

--- a/web/app/components/header/index.tsx
+++ b/web/app/components/header/index.tsx
@@ -11,6 +11,7 @@ import EnvNav from './env-nav'
 import PluginsNav from './plugins-nav'
 import ExploreNav from './explore-nav'
 import ToolsNav from './tools-nav'
+import ApiOrchestrationNav from './api-orchestration-nav'
 import { WorkspaceProvider } from '@/context/workspace-context'
 import { useAppContext } from '@/context/app-context'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
@@ -102,6 +103,7 @@ const Header = () => {
             {!isCurrentWorkspaceDatasetOperator && <ExploreNav className={navClassName} />}
             {!isCurrentWorkspaceDatasetOperator && <AppNav />}
             {(isCurrentWorkspaceEditor || isCurrentWorkspaceDatasetOperator) && <DatasetNav />}
+            {!isCurrentWorkspaceDatasetOperator && <ApiOrchestrationNav className={navClassName} />}
             {!isCurrentWorkspaceDatasetOperator && <ToolsNav className={navClassName} />}
           </div>
         )
@@ -119,6 +121,7 @@ const Header = () => {
             {!isCurrentWorkspaceDatasetOperator && <ExploreNav className={navClassName} />}
             {!isCurrentWorkspaceDatasetOperator && <AppNav />}
             {(isCurrentWorkspaceEditor || isCurrentWorkspaceDatasetOperator) && <DatasetNav />}
+            {!isCurrentWorkspaceDatasetOperator && <ApiOrchestrationNav className={navClassName} />}
             {!isCurrentWorkspaceDatasetOperator && <ToolsNav className={navClassName} />}
           </div>
         )

--- a/web/i18n/en-US/common.ts
+++ b/web/i18n/en-US/common.ts
@@ -156,6 +156,7 @@ const translation = {
     datasetsTips: 'COMING SOON: Import your own text data or write data in real-time via Webhook for LLM context enhancement.',
     newApp: 'New App',
     newDataset: 'Create Knowledge',
+    apiOrchestration: 'API Orchestration',
     tools: 'Tools',
   },
   userProfile: {

--- a/web/i18n/zh-Hans/common.ts
+++ b/web/i18n/zh-Hans/common.ts
@@ -156,6 +156,7 @@ const translation = {
     datasetsTips: '即将到来: 上传自己的长文本数据，或通过 Webhook 集成自己的数据源',
     newApp: '创建应用',
     newDataset: '创建知识库',
+    apiOrchestration: 'API编排',
     tools: '工具',
   },
   userProfile: {


### PR DESCRIPTION
## Summary
- add API Orchestration page
- include API Orchestration nav component
- show API Orchestration tab in header nav
- add translations for new menu item

## Testing
- `pnpm lint` *(fails: Cannot find package '@antfu/eslint-config')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*